### PR TITLE
Disable Esc for normal mode during autocomplete

### DIFF
--- a/keymaps/vim-mode-plus.cson
+++ b/keymaps/vim-mode-plus.cson
@@ -11,15 +11,17 @@
 
 # all
 # -------------------------
-'atom-text-editor.vim-mode-plus':
+'atom-text-editor.vim-mode-plus:not(.autocomplete-active)':
   'escape': 'vim-mode-plus:reset-normal-mode'
+'atom-text-editor.vim-mode-plus':
   'ctrl-c': 'vim-mode-plus:reset-normal-mode'
   'ctrl-[': 'vim-mode-plus:reset-normal-mode'
 
 # all except normal
 # -------------------------
-'atom-text-editor.vim-mode-plus:not(.normal-mode)':
+'atom-text-editor.vim-mode-plus:not([.normal-mode, .autocomplete-active])':
   'escape': 'vim-mode-plus:activate-normal-mode'
+'atom-text-editor.vim-mode-plus:not(.normal-mode)':
   'ctrl-[': 'vim-mode-plus:activate-normal-mode'
 
 # all except normal


### PR DESCRIPTION
Esc normally rejects the autocomplete suggestion, but vim-mode-plus overrides this behaviour - with vim-mode-plus on, the autocomplete suggestion is rejected and you are returned to Normal mode, which is unlikely to be what you want.

This change limits the vim-mode-plus keybinding of Esc to only work outside of autocomplete. Ctrl-c and ctrl-[ still work to exit autocomplete and return to Normal mode.

Fixes #1149